### PR TITLE
Release v1.0.2: uninstall cleanup choice and diagnostics defaults

### DIFF
--- a/BUILD_INFO.txt
+++ b/BUILD_INFO.txt
@@ -1,4 +1,12 @@
-Low Latency Capture Viewer v1.0.1 x64 (continued from the v0.14.2 rework)
+Low Latency Capture Viewer v1.0.2 x64 (continued from the v0.14.2 rework)
+
+v1.0.2 uninstall cleanup choice
+--------------------------------
+- The Inno Setup uninstaller now asks whether to remove per-user settings and
+  diagnostic logs. No preserves them for reinstall; Yes removes them.
+- Diagnostic console visibility is configurable and defaults to hidden.
+- Audio diagnostics use a separate five-second warm-up; video statistics keep
+  the two-second warm-up.
 
 v1.0.1 language selection
 -------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24)
-project(LowLatencyCaptureViewer VERSION 1.0.1 LANGUAGES CXX)
+project(LowLatencyCaptureViewer VERSION 1.0.2 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/DESIGN.txt
+++ b/DESIGN.txt
@@ -1,4 +1,4 @@
-Low Latency Capture Viewer v1.0.1 design (continued from v0.14.2)
+Low Latency Capture Viewer v1.0.2 design (continued from v0.14.2)
 
 v1.0.1 language selection
 -------------------------

--- a/GITHUB_PREP.md
+++ b/GITHUB_PREP.md
@@ -18,7 +18,7 @@ binary. Release builds use the static MSVC runtime. A target PC still needs
 the capture-card driver and the Windows multimedia components listed in
 `DEPENDENCIES.txt`.
 
-The v1.0.1 distribution has two forms: an Inno Setup installer for Program
+The v1.0.2 distribution has two forms: an Inno Setup installer for Program
 Files and a portable x64 ZIP. Both keep settings and optional logs under
 `%LOCALAPPDATA%\\LowLatencyCaptureViewer`; they do not ship a machine-specific
 `settings.ini`.

--- a/README.ko.md
+++ b/README.ko.md
@@ -37,18 +37,19 @@ GC573가 테스트·권장 장치입니다. 다른 장치는 실험적이며, �
 
 ## 설치 및 실행
 
-1. `LowLatencyCaptureViewer_v1.0.1_Setup.exe`를 실행하고 설치합니다.
+1. `LowLatencyCaptureViewer_v1.0.2_Setup.exe`를 실행하고 설치합니다.
 2. 시작 메뉴의 **Low Latency Capture Viewer** 또는 설치된 실행 파일을
    실행합니다.
 
-포터블판 `LowLatencyCaptureViewer_v1.0.1_x64.zip`도 함께 제공합니다. 원하는
+포터블판 `LowLatencyCaptureViewer_v1.0.2_x64.zip`도 함께 제공합니다. 원하는
 폴더에 압축을 풀고 `LowLatencyCaptureViewer.exe`를 실행하면 됩니다.
 
 설정과 진단 로그는 사용자별로
 `%LOCALAPPDATA%\\LowLatencyCaptureViewer`에 저장됩니다. 기존에 실행 파일 옆에
 있던 `settings.ini`가 있으면 첫 실행 때 이 위치로 자동 복사하며 기존 파일은
-삭제하지 않습니다. 제거 프로그램도 이 사용자 데이터를 남겨 재설치 시 설정과
-진단 로그를 보존합니다.
+삭제하지 않습니다. 제거 프로그램은 기본적으로 이 데이터를 보존하며, 제거
+과정에서 삭제 여부를 묻습니다. **아니오**를 선택하면 다음 설치를 위해 설정과
+진단 로그를 유지하고, **예**를 선택하면 영구적으로 삭제합니다.
 
 앱 하나에 한국어·영어 UI가 함께 포함됩니다. 설정 창의 **언어 / Language**에서
 자동(Windows 언어), 한국어, English를 선택할 수 있으며, 선택값은 사용자별로

--- a/README.md
+++ b/README.md
@@ -37,18 +37,19 @@ reconnect are not supported.
 
 ## Install and run
 
-1. Run `LowLatencyCaptureViewer_v1.0.1_Setup.exe` and follow the wizard.
+1. Run `LowLatencyCaptureViewer_v1.0.2_Setup.exe` and follow the wizard.
 2. Launch **Low Latency Capture Viewer** from the Start menu or the installed
    executable.
 
-A portable `LowLatencyCaptureViewer_v1.0.1_x64.zip` is also available. Extract
+A portable `LowLatencyCaptureViewer_v1.0.2_x64.zip` is also available. Extract
 it anywhere and run `LowLatencyCaptureViewer.exe`.
 
 Settings and diagnostic logs are stored per user in
 `%LOCALAPPDATA%\\LowLatencyCaptureViewer`. An older `settings.ini` beside the
 executable is copied there automatically on first launch; it is not deleted.
-The uninstaller leaves this user data in place so reinstalling does not erase
-preferences or diagnostics.
+The uninstaller keeps this data by default and asks whether to remove it. Choose
+**No** to preserve preferences and diagnostics for a future reinstall, or
+**Yes** to delete them permanently.
 
 The application contains Korean and English UI strings in one executable. The
 settings dialog offers **Auto (Windows language)**, **한국어**, and **English**;

--- a/installer/LowLatencyCaptureViewer.iss
+++ b/installer/LowLatencyCaptureViewer.iss
@@ -1,8 +1,8 @@
-; Low Latency Capture Viewer v1.0.1
+; Low Latency Capture Viewer v1.0.2
 ; Build this script with Inno Setup 6 or newer from the installer directory.
 
 #define MyAppName "Low Latency Capture Viewer"
-#define MyAppVersion "1.0.1"
+#define MyAppVersion "1.0.2"
 #define MyAppPublisher "seria-aa"
 #define MyAppURL "https://github.com/seria-aa/LowLatencyCaptureViewer"
 #define MyAppExeName "LowLatencyCaptureViewer.exe"
@@ -22,8 +22,8 @@ DisableProgramGroupPage=yes
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 PrivilegesRequired=admin
-OutputDir=..\..\outputs\v1.0.1
-OutputBaseFilename=LowLatencyCaptureViewer_v1.0.1_Setup
+OutputDir=..\..\outputs\v1.0.2
+OutputBaseFilename=LowLatencyCaptureViewer_v1.0.2_Setup
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
@@ -31,7 +31,7 @@ CloseApplications=yes
 SetupIconFile=..\assets\LowLatencyCaptureViewer.ico
 UninstallDisplayIcon={app}\{#MyAppExeName}
 Uninstallable=yes
-VersionInfoVersion=1.0.1.0
+VersionInfoVersion=1.0.2.0
 VersionInfoCompany={#MyAppPublisher}
 VersionInfoDescription={#MyAppName}
 VersionInfoCopyright=Copyright (C) 2026 seria-aa
@@ -39,6 +39,10 @@ VersionInfoCopyright=Copyright (C) 2026 seria-aa
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "korean"; MessagesFile: "compiler:Languages\Korean.isl"
+
+[CustomMessages]
+english.DeleteUserDataPrompt=Do you also want to delete your settings and diagnostic logs?%n%nChoose No to keep them for a future reinstall, or Yes to remove them permanently.
+korean.DeleteUserDataPrompt=사용자 설정과 진단 로그도 삭제하시겠습니까?%n%n아니오를 선택하면 다음 설치를 위해 보존하고, 예를 선택하면 영구적으로 삭제합니다.
 
 [Tasks]
 Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional icons:"; Flags: unchecked
@@ -59,5 +63,28 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; Flags: nowait postinstall skipifsilent
 
-; User settings and logs under %LOCALAPPDATA% are intentionally not removed by
-; the uninstaller, so a reinstall preserves the user's configuration.
+[Code]
+var
+  DeleteUserData: Boolean;
+
+function InitializeUninstall(): Boolean;
+begin
+  Result := True;
+  DeleteUserData := False;
+  if UninstallSilent then
+    Exit;
+
+  if not DirExists(ExpandConstant('{localappdata}\LowLatencyCaptureViewer')) then
+    Exit;
+
+  DeleteUserData := MsgBox(
+    ExpandConstant('{cm:DeleteUserDataPrompt}'), mbConfirmation,
+    MB_YESNO or MB_DEFBUTTON2) = IDYES;
+end;
+
+procedure CurUninstallStepChanged(UninstallStep: TUninstallStep);
+begin
+  if (UninstallStep = usPostUninstall) and DeleteUserData then
+    DelTree(ExpandConstant('{localappdata}\LowLatencyCaptureViewer'),
+      True, True, True);
+end;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,6 +172,7 @@ struct AppSettings {
     std::wstring captureDeviceId;
     std::wstring audioOutputDeviceId;
     bool saveLog = false;
+    bool showDiagnosticConsole = false;
     bool pixelPerfect = true;
     bool relativeWindowSize = false;
     int relativeWindowScalePpm = 0;
@@ -269,6 +270,7 @@ static const wchar_t* UiText(const wchar_t* korean) {
         {L"제목 표시줄 숨기기 (borderless 창)", L"Hide title bar (borderless window)"},
         {L"창을 모니터 가장자리에 스냅 (권장)", L"Snap window to monitor edges (recommended)"},
         {L"진단 로그 파일 저장 (사용자 폴더)", L"Save diagnostic log (user folder)"},
+        {L"진단 콘솔 창 표시", L"Show diagnostic console window"},
         {L"언어 / Language", L"Language"},
         {L"Low Latency Capture Viewer 설정", L"Low Latency Capture Viewer Settings"},
         {L"시작", L"Start"},
@@ -280,7 +282,7 @@ static const wchar_t* UiText(const wchar_t* korean) {
         {L"%llu시간 %llu분 전", L"%llu hours %llu minutes ago"},
         {L"측정 대기 중", L"Waiting for measurement"},
         {L"측정 중", L"Measuring"},
-        {L"워밍업 · 시작 2초 제외", L"Warm-up · first 2 seconds excluded"},
+        {L"워밍업 · 시작 5초 제외", L"Warm-up · first 5 seconds excluded"},
         {L"리샘플러 출력 부족 감지", L"Resampler output shortage detected"},
         {L"리샘플러 보정 한계 접근", L"Resampler correction limit approaching"},
         {L"리샘플러 정상 작동", L"Resampler operating normally"},
@@ -371,7 +373,9 @@ static std::atomic<double> g_osdInputFps{0.0};
 static std::atomic<double> g_osdPresentFps{0.0};
 static std::atomic<bool> g_osdVisible{false};
 static constexpr uint64_t kOsdTrackingWarmupMs = 2000;
+static constexpr uint64_t kAudioTrackingWarmupMs = 5000;
 static std::atomic<uint64_t> g_osdTrackingStartMs{UINT64_MAX};
+static std::atomic<uint64_t> g_audioTrackingStartMs{UINT64_MAX};
 static std::atomic<bool> g_captureAudioAvailable{true};
 static std::wstring g_activeCaptureDeviceName = kCaptureName;
 static std::wstring g_activeAudioOutputName = L"Windows 기본 장치";
@@ -431,6 +435,11 @@ static DXGI_FORMAT PixelFormatDxgi(VideoPixelFormat format) {
 static bool OsdTrackingActive() {
     return GetTickCount64() >=
         g_osdTrackingStartMs.load(std::memory_order_acquire);
+}
+
+static bool AudioTrackingActive() {
+    return GetTickCount64() >=
+        g_audioTrackingStartMs.load(std::memory_order_acquire);
 }
 
 static void SetActiveAudioOutputName(const std::wstring& name) {
@@ -862,6 +871,7 @@ static void LoadSettings() {
     wchar_t windowY[32]{};
     wchar_t monitorDevice[64]{};
     wchar_t saveLog[8]{};
+    wchar_t showDiagnosticConsole[8]{};
 
     GetPrivateProfileStringW(L"General", L"Language", L"Auto", language,
                              ARRAYSIZE(language), path.c_str());
@@ -921,6 +931,9 @@ static void LoadSettings() {
                              ARRAYSIZE(monitorDevice), path.c_str());
     GetPrivateProfileStringW(L"Diagnostics", L"SaveLog", L"0", saveLog,
                              ARRAYSIZE(saveLog), path.c_str());
+    GetPrivateProfileStringW(L"Diagnostics", L"ShowConsole", L"0",
+                             showDiagnosticConsole,
+                             ARRAYSIZE(showDiagnosticConsole), path.c_str());
 
     if (_wcsicmp(language, L"English") == 0) {
         g_settings.uiLanguage = UiLanguage::English;
@@ -996,6 +1009,8 @@ static void LoadSettings() {
         wcstol(frameRate, nullptr, 10));
     g_settings.videoFrameRate = savedFrameRate > 0 ? savedFrameRate : 0;
     g_settings.saveLog = wcstol(saveLog, nullptr, 10) != 0;
+    g_settings.showDiagnosticConsole =
+        wcstol(showDiagnosticConsole, nullptr, 10) != 0;
 
     if (_wcsicmp(resolution, L"1920x1080") == 0) {
         g_settings.videoPreset = VideoPreset::R1920x1080;
@@ -1101,6 +1116,9 @@ static void SaveSettings() {
     WritePrivateProfileStringW(L"Diagnostics", L"SaveLog",
                                g_settings.saveLog ? L"1" : L"0",
                                path.c_str());
+    WritePrivateProfileStringW(L"Diagnostics", L"ShowConsole",
+                               g_settings.showDiagnosticConsole ? L"1" : L"0",
+                               path.c_str());
 }
 
 // -----------------------------------------------------------------------------
@@ -1128,7 +1146,7 @@ public:
             const size_t drop = std::min(available_ + frames - kRingFrames, available_);
             readFrame_ = (readFrame_ + drop) % kRingFrames;
             available_ -= drop;
-            if (OsdTrackingActive()) {
+            if (AudioTrackingActive()) {
                 overruns_++;
                 g_audioOverrunFrames.fetch_add(drop,
                                                std::memory_order_relaxed);
@@ -1369,7 +1387,7 @@ public:
 
         const size_t frames = static_cast<size_t>(bytes / bytesPerFrame);
         const uint64_t nowMs = GetTickCount64();
-        const bool track = OsdTrackingActive();
+        const bool track = AudioTrackingActive();
         if (track) {
             uint64_t unsetStart = 0;
             g_audioMonitorStartMs.compare_exchange_strong(
@@ -1949,7 +1967,7 @@ static bool AudioRenderThreadWasapi(AudioMode mode,
             size_t got = 0;
             const size_t availableBeforeRender =
                 g_ring.availableFrames() + driftResampler.bufferedFrames();
-            if (audioStarted && OsdTrackingActive()) {
+            if (audioStarted && AudioTrackingActive()) {
                 UINT32 observed = static_cast<UINT32>((std::min)(
                     availableBeforeRender,
                     static_cast<size_t>(UINT32_MAX)));
@@ -2029,7 +2047,7 @@ static bool AudioRenderThreadWasapi(AudioMode mode,
             if (got < writable) {
                 memset(out + got * wf.nBlockAlign, 0,
                        (writable - static_cast<UINT32>(got)) * wf.nBlockAlign);
-                if (audioStarted && OsdTrackingActive()) {
+                if (audioStarted && AudioTrackingActive()) {
                     g_underruns++;
                     g_audioUnderrunFrames.fetch_add(
                         writable - static_cast<UINT32>(got),
@@ -3479,6 +3497,7 @@ constexpr int IDC_SETTINGS_MUTE_BACKGROUND = 2021;
 constexpr int IDC_SETTINGS_PRESENTATION_HELP = 2022;
 constexpr int IDC_SETTINGS_PCM_QUEUE_HELP = 2023;
 constexpr int IDC_SETTINGS_LANGUAGE = 2024;
+constexpr int IDC_SETTINGS_SHOW_CONSOLE = 2025;
 constexpr UINT WM_AUDIOCLIENT3_PROBE_COMPLETE = WM_APP + 73;
 constexpr UINT WM_SETTINGS_TOOLTIP_SHOW = WM_APP + 74;
 constexpr UINT WM_SETTINGS_TOOLTIP_HIDE = WM_APP + 75;
@@ -3520,6 +3539,7 @@ struct SettingsDialogState {
     HWND borderlessCheck = nullptr;
     HWND windowSnapCheck = nullptr;
     HWND saveLogCheck = nullptr;
+    HWND showConsoleCheck = nullptr;
     HWND startButton = nullptr;
     HWND cancelButton = nullptr;
     HWND tooltipWindow = nullptr;
@@ -3642,6 +3662,7 @@ static void LayoutSettingsControls(SettingsDialogState* state, UINT dpi) {
     PlaceSettingsControl(state->borderlessCheck, 505, 370, 420, 28, dpi);
     PlaceSettingsControl(state->windowSnapCheck, 505, 404, 420, 28, dpi);
     PlaceSettingsControl(state->saveLogCheck, 505, 438, 420, 28, dpi);
+    PlaceSettingsControl(state->showConsoleCheck, 505, 472, 420, 28, dpi);
     PlaceSettingsControl(state->startButton, 745, 552, 80, 30, dpi);
     PlaceSettingsControl(state->cancelButton, 835, 552, 80, 30, dpi);
 }
@@ -4194,6 +4215,8 @@ static void FinishSettingsDialog(HWND hwnd, SettingsDialogState* state, bool acc
         }
         g_settings.saveLog = SendMessageW(
             state->saveLogCheck, BM_GETCHECK, 0, 0) == BST_CHECKED;
+        g_settings.showDiagnosticConsole = SendMessageW(
+            state->showConsoleCheck, BM_GETCHECK, 0, 0) == BST_CHECKED;
         g_settings.muteWhenBackground = SendMessageW(
             state->muteBackgroundCheck, BM_GETCHECK, 0, 0) == BST_CHECKED;
         g_settings.pixelPerfect = SendMessageW(
@@ -4577,6 +4600,17 @@ static LRESULT CALLBACK SettingsWndProc(HWND hwnd, UINT msg,
             instance, nullptr);
         SendMessageW(state->saveLogCheck, BM_SETCHECK,
                      g_settings.saveLog ? BST_CHECKED : BST_UNCHECKED, 0);
+
+        state->showConsoleCheck = CreateWindowExW(
+            0, L"BUTTON", UI_TEXT(L"진단 콘솔 창 표시"),
+            WS_CHILD | WS_VISIBLE | BS_AUTOCHECKBOX | WS_TABSTOP,
+            430, 408, 365, 28, hwnd,
+            reinterpret_cast<HMENU>(
+                static_cast<INT_PTR>(IDC_SETTINGS_SHOW_CONSOLE)),
+            instance, nullptr);
+        SendMessageW(state->showConsoleCheck, BM_SETCHECK,
+                     g_settings.showDiagnosticConsole
+                         ? BST_CHECKED : BST_UNCHECKED, 0);
 
         state->startButton = CreateWindowExW(
             0, L"BUTTON", UI_TEXT(L"시작"), WS_CHILD | WS_VISIBLE | BS_DEFPUSHBUTTON | WS_TABSTOP,
@@ -5568,9 +5602,9 @@ static std::wstring BuildRuntimeOsdText(int outputWidth, int outputHeight) {
 
     const int activeCorrectionPpm =
         g_audioResamplePpm.load(std::memory_order_acquire);
-    const bool trackingActive = OsdTrackingActive();
+    const bool trackingActive = AudioTrackingActive();
     const wchar_t* clockDiagnosis = trackingActive
-        ? UI_TEXT(L"측정 중") : UI_TEXT(L"워밍업 · 시작 2초 제외");
+        ? UI_TEXT(L"측정 중") : UI_TEXT(L"워밍업 · 시작 5초 제외");
     if (monitorStartMs) {
         if (g_settings.driftCorrection ==
             DriftCorrectionMode::Resample) {
@@ -5604,7 +5638,7 @@ static std::wstring BuildRuntimeOsdText(int outputWidth, int outputHeight) {
     }
 
     const wchar_t* queueDiagnosis = trackingActive
-        ? UI_TEXT(L"측정 중") : UI_TEXT(L"워밍업 · 시작 2초 제외");
+        ? UI_TEXT(L"측정 중") : UI_TEXT(L"워밍업 · 시작 5초 제외");
     if (monitorStartMs) {
         if (underrunEvents == 0) {
             queueDiagnosis = g_settings.pcmQueueTargetMs ==
@@ -5972,7 +6006,15 @@ int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR commandLine, int show) {
     if (!smokeTest && !ShowSettingsDialog(hInst)) return 0;
 
     // Allocate a console for prototype diagnostics.
-    AllocConsole();
+    const BOOL allocatedConsole = AllocConsole();
+    if (allocatedConsole && !g_settings.showDiagnosticConsole) {
+        const HWND console = GetConsoleWindow();
+        if (console) ShowWindow(console, SW_HIDE);
+    }
+    if (allocatedConsole && g_settings.showDiagnosticConsole) {
+        const HWND console = GetConsoleWindow();
+        if (console) ShowWindow(console, SW_SHOW);
+    }
     FILE* f = nullptr;
     if (smokeTest) {
         EnsureUserDataDirectory();
@@ -6089,11 +6131,17 @@ int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR commandLine, int show) {
         ToggleFullscreen(hwnd);
     }
 
-    g_osdTrackingStartMs.store(GetTickCount64() + kOsdTrackingWarmupMs,
+    const uint64_t trackingStartMs = GetTickCount64();
+    g_osdTrackingStartMs.store(trackingStartMs + kOsdTrackingWarmupMs,
                                std::memory_order_release);
+    g_audioTrackingStartMs.store(trackingStartMs + kAudioTrackingWarmupMs,
+                                 std::memory_order_release);
     fwprintf(stderr,
-             L"[osd] statistics warmup: first %llu ms excluded.\n",
+             L"[osd] video statistics warmup: first %llu ms excluded.\n",
              static_cast<unsigned long long>(kOsdTrackingWarmupMs));
+    fwprintf(stderr,
+             L"[osd] audio diagnostics warmup: first %llu ms excluded.\n",
+             static_cast<unsigned long long>(kAudioTrackingWarmupMs));
 
     // One DirectShow graph owns one selected capture-filter instance and both
     // its video and audio branches. WASAPI remains an independent consumer.

--- a/tools/package-v1.ps1
+++ b/tools/package-v1.ps1
@@ -1,14 +1,14 @@
 param(
     [string]$BuildDir = "..\build-v100-release",
-    [string]$OutputDir = "..\outputs\v1.0.1"
+    [string]$OutputDir = "..\outputs\v1.0.2"
 )
 
 $ErrorActionPreference = "Stop"
 $root = (Resolve-Path (Join-Path $PSScriptRoot ".." )).Path
 $build = (Resolve-Path (Join-Path $PSScriptRoot $BuildDir)).Path
 $output = Join-Path $root $OutputDir
-$portable = Join-Path $output "LowLatencyCaptureViewer_v1.0.1_x64"
-$zip = Join-Path $output "LowLatencyCaptureViewer_v1.0.1_x64.zip"
+$portable = Join-Path $output "LowLatencyCaptureViewer_v1.0.2_x64"
+$zip = Join-Path $output "LowLatencyCaptureViewer_v1.0.2_x64.zip"
 $exe = Join-Path $build "LowLatencyCaptureViewer.exe"
 
 if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {

--- a/실행안내.txt
+++ b/실행안내.txt
@@ -1,4 +1,4 @@
-Low Latency Capture Viewer v1.0.1 실행 안내
+Low Latency Capture Viewer v1.0.2 실행 안내
 =======================================
 
 1. GC573 또는 지원할 캡처 장치를 연결합니다.


### PR DESCRIPTION
## English

- Add an uninstall prompt to optionally remove per-user settings and diagnostic logs.
- Hide the diagnostic console by default, with a persistent settings checkbox to show it.
- Separate the audio diagnostics warm-up (5 seconds) from the video statistics warm-up (2 seconds).
- Update installer, portable package scripts, README files, and release metadata for v1.0.2.

Validated with an x64 Release build, Inno Setup compilation, and a real GC573/WASAPI smoke test with zero underruns and overruns.

## 한국어

- 제거 시 사용자 설정·진단 로그 삭제 여부를 선택하는 프롬프트를 추가했습니다.
- 진단 콘솔은 기본적으로 숨기고, 설정 창에서 표시 여부를 저장할 수 있습니다.
- 오디오 진단 워밍업은 5초, 영상 통계 워밍업은 2초로 분리했습니다.
- 설치 프로그램·포터블 패키지·README·릴리스 메타데이터를 1.0.2로 갱신했습니다.

x64 Release 빌드, Inno Setup 컴파일, 실제 GC573/WASAPI 스모크 테스트를 통과했으며 underrun/overrun은 0회였습니다.